### PR TITLE
Update you-get.json

### DIFF
--- a/bucket/you-get.json
+++ b/bucket/you-get.json
@@ -4,7 +4,7 @@
     "version": "0.4.1555",
     "url": [
         "https://github.com/soimort/you-get/releases/download/v0.4.1555/you_get-0.4.1555-py3-none-any.whl#/dl.7z",
-        "https://github.com/soimort/you-get/raw/develop/you-get"
+        "https://raw.githubusercontent.com/soimort/you-get/develop/you-get"
     ],
     "hash": [
         "1b5c30cdfa65ce8051d8290ef7d267c6ea078f0ee1bce78eaa4f85b000162a0b",


### PR DESCRIPTION
原来的链接会自动重定向到这个链接，我看其他bucket也很多是直接用的raw.githubusercontent.com链接

- 这个重定向可能会失败（我猜的）
- 直接用raw.githubusercontent.com可以方便替换，比如我会替换其为raw.fastgit.org