### PR TITLE
update tencent meeting

### DIFF
--- a/bucket/tencent-meeting.json
+++ b/bucket/tencent-meeting.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.5.6.416",
+    "version": "3.7.9.426",
     "description": "Tencent Meeting provides one-stop audio and video conferencing solutions.",
     "homepage": "https://meeting.tencent.com/",
     "license": {
@@ -7,12 +7,13 @@
         "url": "https://meeting.tencent.com/declare.html"
     },
     "notes": "We don't persist your Tencent Meeting data, they are still storaged in \"$env:APPDATA\\Tencent\\WeMeet\".",
-    "url": "https://updatecdn.meeting.qq.com/cos/8d470eda782890abc7cc8cc3c2629cb3/TencentMeeting_0300000000_3.5.6.416.publish.exe#/dl.7z",
-    "hash": "dacd74f99d97c1776b28a971b63818c0afe51146824c242bb826987526222d4e",
-    "pre_install": "Rename-Item -Path \"$dir\\`$_*\" -NewName \"$version\" -Force",
+    "url": "https://updatecdn.meeting.qq.com/cos/fe7d7cb3026cb7e537b947964cabd2c1/TencentMeeting_0300000000_3.7.9.426.publish.exe#/dl.7z",
+    "hash": "faf0b906501ec9fd41ba46a920055eed58ff6fa5ef227e1feb42fb66bbf23ec1",
     "post_install": [
+        "Rename-Item \"$dir\\`$_9_\" \"$dir\\$version\"",
         "Remove-Item \"$dir\\$*\" -Recurse -Force -ErrorAction SilentlyContinue",
-        "Remove-Item \"$dir\\wemeetapp_new.exe\" -Force -ErrorAction SilentlyContinue"
+        "Remove-Item \"$dir\\wemeetapp_new.exe\" -Force -ErrorAction SilentlyContinue",
+        "create_startmenu_shortcuts $manifest $dir\\..\\$version $global $arch"
     ],
     "bin": [
         [


### PR DESCRIPTION
update tencent-meeting to version "3.7.9.426"
tencent-meeting cannot open in "\current\wemeetapp.exe" so I create shortcut by function 'create_startmenu_shortcuts' in scoop. And now the shortcut start from '$version\wemeetapp.exe'. 

test env: Windows 11 Pro 22000.675 
scoop ver: v0.2.0 - Released at 2022-05-10
