### PR TITLE
QQ-NT: update to 9.9.9, update checkver

### DIFF
--- a/bucket/qq-nt.json
+++ b/bucket/qq-nt.json
@@ -37,7 +37,7 @@
     },
     "checkver": {
         "url": "https://cdn-go.cn/qq-web/im.qq.com_new/latest/rainbow/windowsDownloadUrl.js",
-        "regex": "\"ntVersion\":\"(?<Version>[\\d.]+)\".*\"ntPublishTime\":\"[\\d年月日]+\".*\"newTag\":.*?.*\"ntDownloadUrl\":\"(?<Url>[^\"]+)\".*\"ntDownloadX64Url\":\"(?<Url64>[^\"]+)\""
+        "regex": "\"ntVersion\":\"(?<Version>[\\d.]+)\"|\"ntPublishTime\":\"[\\d年月日]+\"|\"ntDownloadUrl\":\"(?<Url>[^\"]+)\"|\"ntDownloadX64Url\":\"(?<Url64>[^\"]+)\""
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/qq-nt.json
+++ b/bucket/qq-nt.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.9.7.21484",
+    "version": "9.9.9",
     "description": "An instant messaging tool that gives you the best way to keep in touch with your friends and family, Build with Electron",
     "homepage": "https://im.qq.com",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/897bf087/QQ9.9.7.21484_x64.exe#/dl.7z",
-            "hash": "97ff95d3ff4055449912f4702f283c079efb4df872c2ad288a1993e4a661bff9"
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.9_240403_x64_01.exe#/dl.7z",
+            "hash": "26be961ef624775ebf1732485be994f8a850159054620d0b382548812dc70713"
         },
         "32bit": {
-            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/340572d2/QQ9.9.7.21484_x86.exe#/dl.7z",
-            "hash": "fca60b9b6e813c5f266cc6b6e076465702d1352de17cfb765c618bbab29366e1"
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.9_240403_x86_01.exe#/dl.7z",
+            "hash": "04645699bd777fdb89cbc074e078f13b808b5aeff52c8795f4ab377586a76a67"
         }
     },
     "installer": {
@@ -37,15 +37,15 @@
     },
     "checkver": {
         "url": "https://cdn-go.cn/qq-web/im.qq.com_new/latest/rainbow/windowsDownloadUrl.js",
-        "regex": "QQNT/(?<Commitidx64>[0-9a-f]+)/QQ(?<Version>[\\d.]+)_x64.exe.*QQNT/(?<Commitidx86>[0-9a-f]+)/QQ(?<Version>[\\d.]+)_x86.exe|QQNT/(?<Commitidx86>[0-9a-f]+)/QQ(?<Version>[\\d.]+)_x86.exe.*QQNT/(?<Commitidx64>[0-9a-f]+)/QQ(?<Version>[\\d.]+)_x64.exe"
+        "regex": "\"ntVersion\":\"(?<Version>[\\d.]+)\".*\"ntPublishTime\":\"[\\d年月日]+\".*\"newTag\":.*?.*\"ntDownloadUrl\":\"(?<Url>[^\"]+)\".*\"ntDownloadX64Url\":\"(?<Url64>[^\"]+)\""
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dldir1.qq.com/qqfile/qq/QQNT/$matchCommitidx64/QQ$matchVersion_x64.exe#/dl.7z"
+                "url": "$matchUrl64#/dl.7z"
             },
             "32bit": {
-                "url": "https://dldir1.qq.com/qqfile/qq/QQNT/$matchCommitidx86/QQ$matchVersion_x86.exe#/dl.7z"
+                "url": "$matchUrl#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
修改checkver正则匹配，可以匹配正确的版本

好像新版js里面没有commit号，不知道如何获取