### PR TITLE
qq-nt: fix checkver and update to 9.9.11

### DIFF
--- a/bucket/qq-nt.json
+++ b/bucket/qq-nt.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.9.9",
+    "version": "9.9.11",
     "description": "An instant messaging tool that gives you the best way to keep in touch with your friends and family, Build with Electron",
     "homepage": "https://im.qq.com",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.9_240403_x64_01.exe#/dl.7z",
-            "hash": "26be961ef624775ebf1732485be994f8a850159054620d0b382548812dc70713"
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.11_240606_x64_01.exe#/dl.7z",
+            "hash": "281931793c9260c7f220b34e16517f8fb577026186e6c1c94f7eac6489861543"
         },
         "32bit": {
-            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.9_240403_x86_01.exe#/dl.7z",
-            "hash": "04645699bd777fdb89cbc074e078f13b808b5aeff52c8795f4ab377586a76a67"
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.11_240606_x86_01.exe#/dl.7z",
+            "hash": "c14106bfff6ef44a006fc5a6bf8927933e67e8f9d30502f4d54d0736c790cfd4"
         }
     },
     "installer": {
@@ -37,15 +37,15 @@
     },
     "checkver": {
         "url": "https://cdn-go.cn/qq-web/im.qq.com_new/latest/rainbow/windowsDownloadUrl.js",
-        "regex": "\"ntVersion\":\"(?<Version>[\\d.]+)\"|\"ntPublishTime\":\"[\\d年月日]+\"|\"ntDownloadUrl\":\"(?<Url>[^\"]+)\"|\"ntDownloadX64Url\":\"(?<Url64>[^\"]+)\""
+        "regex": "QQNT/Windows/QQ_([\\d.]+)_([\\d.]+)_x86_([\\d.]+).exe.*QQNT/Windows/QQ_([\\d.]+)_([\\d.]+)_x64_([\\d.]+).exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "$matchUrl64#/dl.7z"
+                "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_$match1_$match2_x64_$match3.exe#/dl.7z"
             },
             "32bit": {
-                "url": "$matchUrl#/dl.7z"
+                "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_$match1_$match2_x86_$match3.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
`qq-nt` 的 manifest 没有正常更新，原因是 checkver 与 autoupdate 配置无法正确获取 url，报错如下：

```
.\bin\checkver.ps1 -Dir ..\..\..\buckets\scoopet -App qq-nt -u
qq-nt: 9.9.11 (scoop version is 9.9.9) autoupdate available
Autoupdating qq-nt
ERROR 使用“1”个参数调用“.ctor”时发生异常:“无效的 URI: 未能确定 URI 的格式。”
```

现修改 checkver 正则匹配与 autoupdate 中的 url 配置，能正确自动更新 manifest：

```
.\bin\checkver.ps1 -Dir ..\..\..\buckets\scoopet -App qq-nt -u
qq-nt: 9.9.11 (scoop version is 9.9.9) autoupdate available
Autoupdating qq-nt
Downloading QQ_9.9.11_240606_x86_01.exe to compute hashes!
QQ_9.9.11_240606_x86_01.exe (170.7 MB) [======================================================================] 100%
Computed hash: c14106bfff6ef44a006fc5a6bf8927933e67e8f9d30502f4d54d0736c790cfd4
Downloading QQ_9.9.11_240606_x64_01.exe to compute hashes!
QQ_9.9.11_240606_x64_01.exe (183.8 MB) [======================================================================] 100%
Computed hash: 281931793c9260c7f220b34e16517f8fb577026186e6c1c94f7eac6489861543
Writing updated qq-nt manifest
```