### PR TITLE
bugfix: Rename-Item path do not accept wildcard characters

### DIFF
--- a/bucket/tencent-meeting.json
+++ b/bucket/tencent-meeting.json
@@ -9,7 +9,7 @@
     "url": "https://updatecdn.meeting.qq.com/cos/3f0a41ceec643403cc23bb5ecad45ded/TencentMeeting_0300000000_3.30.1.471.publish.officialwebsite.exe#/dl.7z",
     "hash": "md5:3f0a41ceec643403cc23bb5ecad45ded",
     "post_install": [
-        "Rename-Item -Path \"$dir\\`$_*\" -NewName \"$version\" -Force",
+        "Get-ChildItem \"$dir\\`$_*\" | Rename-Item -NewName \"$version\" -Force",
         "Remove-Item \"$dir\\`$*\" -Recurse -Force -ErrorAction SilentlyContinue",
         "Remove-Item \"$dir\\wemeetapp_new.exe\" -Force -ErrorAction SilentlyContinue",
         "create_startmenu_shortcuts $manifest $original_dir $global $architecture",


### PR DESCRIPTION
执行安装命令会报错

```ps
Running post_install script...Rename-Item : 无法处理参数，因为参数“path”的值无效。请更改“path”参数的值，然后再次运行此操作。
所在位置 行:1 字符: 1
+ Rename-Item -Path "$dir\`$_*" -NewName "$version" -Force
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Rename-Item]，PSArgumentException
    + FullyQualifiedErrorId : Argument,Microsoft.PowerShell.Commands.RenameItemCommand
```

查看官方  `Rename-Item`  API

https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/rename-item?view=powershell-7.4#-path

该函数的 `path` 不接受通配符

*该仓库中还存在相似的问题*